### PR TITLE
Create build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: ci
+
+permissions:
+  contents: read
+
+on:
+  push:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    name: build (node v${{ matrix.node }})
+    
+    runs-on: macos-latest
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [ 18, 20 ]
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+      
+      - name: npm ci
+        run: npm ci
+
+      - name: npm test
+        run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,14 @@ on:
 
 jobs:
   build:
-    name: build (node v${{ matrix.node }})
+    name: build (node v${{ matrix.node }} ${{ matrix.os }})
     
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
     
     strategy:
       fail-fast: false
       matrix:
+        os: [ macos-13, macos-15 ]
         node: [ 18, 20 ]
 
     steps:


### PR DESCRIPTION
Run the integration tests on macOS 13 and 15 using NodeJS 18 and 20.

PS: The tool is not compatible with NodeJS 22.