### PR TITLE
Add macOS DMG integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,20 @@ jobs:
       - run: node --check lib/render-progress.js
       - run: node --check test/args.test.js
       - run: node --check test/main.test.js
+
+  integration:
+    name: integration node v24 macos-15-intel
+    runs-on: macos-15-intel
+    needs:
+      - appdmg
+      - cli
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run test:integration
+      - run: node --check test/integration/dmg.test.js

--- a/lib/darwin/hdiutil.js
+++ b/lib/darwin/hdiutil.js
@@ -34,16 +34,24 @@ async function attach (commands, imagePath) {
   ]
 
   const result = await commands.run('hdiutil', args)
-  const mountPath = result.stdout
-    .split('\n')
-    .map((line) => line.trim().split(/\s+/).pop())
-    .find((value) => value && path.isAbsolute(value))
+  const mountPath = parseMountPath(result.stdout)
 
   if (!mountPath) {
     throw new Error('Failed to mount image')
   }
 
   return mountPath
+}
+
+function parseMountPath (stdout) {
+  for (const line of stdout.split('\n')) {
+    const volumeMatch = /(\/Volumes\/.+)$/.exec(line)
+    if (volumeMatch) return volumeMatch[1]
+
+    const tabParts = line.trim().split('\t')
+    const lastTabPart = tabParts[tabParts.length - 1]
+    if (lastTabPart && path.isAbsolute(lastTabPart)) return lastTabPart
+  }
 }
 
 async function detach (commands, mountPath) {
@@ -91,5 +99,6 @@ module.exports = {
   attach,
   convert,
   create,
-  detach
+  detach,
+  parseMountPath
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "node": ">=24"
   },
   "scripts": {
-    "test": "ava"
+    "test": "ava test/*.test.js",
+    "test:integration": "ava test/integration/**/*.test.js"
   },
   "dependencies": {
     "@appdmg/ds-store": "~1.0.0",
@@ -47,10 +48,5 @@
   "overrides": {
     "js-yaml": "~3.14.2",
     "lodash": "~4.18.1"
-  },
-  "ava": {
-    "files": [
-      "test/**/*.test.js"
-    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "test": "ava test/*.test.js",
-    "test:integration": "ava test/integration/**/*.test.js"
+    "test:integration": "ava --timeout=2m --serial test/integration/**/*.test.js"
   },
   "dependencies": {
     "@appdmg/ds-store": "~1.0.0",

--- a/test/integration/dmg.test.js
+++ b/test/integration/dmg.test.js
@@ -11,7 +11,7 @@ const appdmg = require('../..')
 const { parseMountPath } = require('../../lib/darwin/hdiutil')
 
 const execFileAsync = promisify(execFile)
-const macOSTest = process.platform === 'darwin' ? test : test.skip
+const macOSTest = process.platform === 'darwin' ? test.serial : test.skip
 
 macOSTest('creates and inspects a modern DMG specification', async (t) => {
   const tmpDir = await makeTempDir(t)

--- a/test/integration/dmg.test.js
+++ b/test/integration/dmg.test.js
@@ -1,0 +1,142 @@
+'use strict'
+
+const { execFile } = require('node:child_process')
+const fs = require('node:fs/promises')
+const os = require('node:os')
+const path = require('node:path')
+const { promisify } = require('node:util')
+const test = require('ava').default
+
+const appdmg = require('../..')
+const { parseMountPath } = require('../../lib/darwin/hdiutil')
+
+const execFileAsync = promisify(execFile)
+const macOSTest = process.platform === 'darwin' ? test : test.skip
+
+macOSTest('creates and inspects a modern DMG specification', async (t) => {
+  const tmpDir = await makeTempDir(t)
+  const target = path.join(tmpDir, 'modern.dmg')
+
+  await waitForImage(appdmg({
+    source: assetPath('appdmg.json'),
+    target
+  }))
+
+  t.is(await imageFormat(target), 'UDZO')
+
+  await withMountedImage(target, async (mountPath) => {
+    t.regex(path.basename(mountPath), /^Test Title( \d+)?$/)
+    t.true((await fs.stat(path.join(mountPath, 'TestApp.app'))).isDirectory())
+    t.is(await fs.readFile(path.join(mountPath, 'TestDoc.txt'), 'utf8'), 'This is just a test.\n')
+    t.is(await fs.readlink(path.join(mountPath, 'Applications')), '/Applications')
+    t.true((await fs.stat(path.join(mountPath, '.background', 'TestBkg.tiff'))).isFile())
+    t.true((await fs.stat(path.join(mountPath, '.DS_Store'))).isFile())
+    t.true((await fs.stat(path.join(mountPath, '.VolumeIcon.icns'))).isFile())
+  })
+})
+
+macOSTest('keeps legacy JSON input support', async (t) => {
+  const tmpDir = await makeTempDir(t)
+  const target = path.join(tmpDir, 'legacy.dmg')
+
+  await waitForImage(appdmg({
+    source: assetPath('appdmg-legacy.json'),
+    target
+  }))
+
+  t.is(await imageFormat(target), 'UDZO')
+
+  await withMountedImage(target, async (mountPath) => {
+    t.true((await fs.stat(path.join(mountPath, 'TestApp.app'))).isDirectory())
+    t.is(await fs.readlink(path.join(mountPath, 'Applications')), '/Applications')
+  })
+})
+
+macOSTest('creates a DMG with custom names and explicit format', async (t) => {
+  const tmpDir = await makeTempDir(t)
+  const target = path.join(tmpDir, 'custom.dmg')
+
+  await waitForImage(appdmg({
+    target,
+    basepath: assetPath('.'),
+    specification: {
+      title: 'Custom Names',
+      format: 'UDRO',
+      background: 'TestBkg.png',
+      contents: [
+        { x: 448, y: 344, type: 'link', path: '/Applications', name: 'System Apps' },
+        { x: 192, y: 344, type: 'file', path: 'TestApp.app', name: 'My Nice App.app' },
+        { x: 512, y: 128, type: 'file', path: 'TestDoc.txt', name: 'Documentation.txt' }
+      ]
+    }
+  }))
+
+  t.is(await imageFormat(target), 'UDRO')
+
+  await withMountedImage(target, async (mountPath) => {
+    t.is(await fs.readlink(path.join(mountPath, 'System Apps')), '/Applications')
+    t.true((await fs.stat(path.join(mountPath, 'My Nice App.app'))).isDirectory())
+    t.is(await fs.readFile(path.join(mountPath, 'Documentation.txt'), 'utf8'), 'This is just a test.\n')
+    t.true((await fs.stat(path.join(mountPath, '.background', 'TestBkg.tiff'))).isFile())
+    t.true((await fs.stat(path.join(mountPath, '.DS_Store'))).isFile())
+  })
+})
+
+function waitForImage (image) {
+  return new Promise((resolve, reject) => {
+    image.once('finish', resolve)
+    image.once('error', reject)
+  })
+}
+
+async function imageFormat (imagePath) {
+  const result = await execFileAsync('hdiutil', ['imageinfo', '-format', imagePath])
+  return result.stdout.trim()
+}
+
+async function withMountedImage (imagePath, fn) {
+  const mountPath = await attach(imagePath)
+
+  try {
+    await fn(mountPath)
+  } finally {
+    await detach(mountPath)
+  }
+}
+
+async function attach (imagePath) {
+  const result = await execFileAsync('hdiutil', [
+    'attach',
+    imagePath,
+    '-readonly',
+    '-nobrowse',
+    '-noverify',
+    '-noautoopen'
+  ])
+
+  const mountPath = parseMountPath(result.stdout)
+
+  if (!mountPath) {
+    throw new Error('Failed to mount image during integration test')
+  }
+
+  return mountPath
+}
+
+async function detach (mountPath) {
+  await execFileAsync('hdiutil', ['detach', mountPath])
+}
+
+function assetPath (name) {
+  return path.join(__dirname, '..', 'assets', name)
+}
+
+async function makeTempDir (t) {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'appdmg-integration-'))
+
+  t.teardown(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  return tmpDir
+}


### PR DESCRIPTION
## Summary

Adds the macOS integration workflow for the Node 24 appdmg packages.

- adds `npm run test:integration` for real DMG-generation tests
- creates, mounts, inspects, and detaches generated DMGs on macOS
- covers modern JSON, legacy JSON, custom names, explicit image format, mounted volume, app bundle, document file, `/Applications` symlink, background assets, `.VolumeIcon.icns`, and `.DS_Store`
- keeps `npm test` as the fast unit suite
- adds a dedicated macOS integration CI job after the appdmg and CLI unit jobs
- hardens the `hdiutil attach` mount parser for volume names containing spaces
- keeps screenshot/capture-window comparison out of the default test path

## Verification

- `npm test`
- `npm run test:integration`
- `npm audit --audit-level=moderate`
- `npm ls --omit=dev --all`
- `npm pack --dry-run`
- `node --check ...` for library sources and tests
- `npm ci && npm test && npm audit --audit-level=moderate && npm ls --omit=dev --all && npm pack --dry-run && node --check ...` in `packages/cli`
- workflow YAML parse

Closes #8
